### PR TITLE
feat: show setup steps in debug window

### DIFF
--- a/components/DebugWindow.tsx
+++ b/components/DebugWindow.tsx
@@ -14,7 +14,11 @@ export const DebugWindow = forwardRef<
   DebugWindowRef,
   { dict: Dictionary; progress?: number }
 >((props, ref) => {
-  const [info, setInfo] = useState(["Welcome!"]);
+  const [info, setInfo] = useState([
+    "1. Connect device",
+    "2. Select firmware",
+    "3. Click Flash",
+  ]);
 
   useImperativeHandle(ref, () => ({
     addInfo: (newInfo: string) => {


### PR DESCRIPTION
## Summary
- show device flashing steps by default in DebugWindow so new users see workflow

## Testing
- `pnpm lint` (fails: 'ThemeProvider' is defined but never used, etc.)
- `pnpm lint --file components/DebugWindow.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a129518824832d9fef481a9fd365c9