### PR TITLE
Handle errors when connecting to device

### DIFF
--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -113,11 +113,15 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
       } as LoaderOptions;
 
       const loader = new ESPLoader(flashOptions);
-      await loader.main().then(() => {
-        toast.success(dict?.tools.connectSuccess);
-      });
+      await loader.main();
+      toast.success(dict?.tools.connectSuccess);
       setDevice(transport);
       setEsploader(loader);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : String(error);
+      handleAddInfo(message);
+      toast.error(message);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- show toast and debug info when device connection fails
- ensure loading state resets on connection success and failure

## Testing
- `pnpm lint` *(fails: 'ThemeProvider' is defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a12c92c128832dbf94e11e85ef4261