### PR TITLE
Reset progress after flashing and fix DebugWindow scale

### DIFF
--- a/components/DebugWindow.tsx
+++ b/components/DebugWindow.tsx
@@ -59,7 +59,7 @@ export const DebugWindow = forwardRef<
         ))}
       </div>
       <div className="p-4 border-t">
-        <Progress value={props.progress} max={10} aria-label="Loading..." />
+        <Progress value={props.progress} max={100} aria-label="Loading..." />
       </div>
     </div>
   );

--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -73,7 +73,7 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
   const [esploader, setEsploader] = useState<ESPLoader | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
 
-  const [progress, setProgress] = useState(-1);
+  const [progress, setProgress] = useState(0);
   const [onlineSelect, setOnlineSelect] = useState<string>();
 
   const fileRef = useRef<HTMLInputElement>(null);
@@ -161,6 +161,7 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
 
     try {
       setLoading(true);
+      setProgress(0);
       await esploader.writeFlash(flashOptions);
       await esploader.after();
       handleAddInfo("Flash complete");
@@ -169,6 +170,7 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
       console.error("Flash error:", error);
     } finally {
       setLoading(false);
+      setProgress(0);
     }
   };
 


### PR DESCRIPTION
## Summary
- initialize progress at 0 and reset after each flash
- use a 0–100 scale for DebugWindow progress bar

## Testing
- `pnpm lint` *(fails: unused variables in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a12e49f740832db974aa8e2cbd9f92