### PR TITLE
Fix firmware flash success typo

### DIFF
--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -77,7 +77,7 @@
     "clearDebugInfo": "Clear Debug Info",
     "uploadFirmware": "Upload Firmware",
     "connectSuccess": "Connect Success",
-    "flashSuccess": "Frimware Flash Success"
+    "flashSuccess": "Firmware Flash Success"
   },
   "docs": {
     "on_this_page": "On this page",


### PR DESCRIPTION
## Summary
- fix typo "Frimware Flash Success" -> "Firmware Flash Success"
- ensure Chinese locale already has correct translation

## Testing
- `pnpm lint` *(fails: several unused vars and type issues)*
- `pnpm build` *(fails: navigator is not defined during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_68a13413a144832d980afeab50a941ac