### PR TITLE
feat: auto connect device with browser support check

### DIFF
--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -77,6 +77,8 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
   const [onlineSelect, setOnlineSelect] = useState<string>();
 
   const fileRef = useRef<HTMLInputElement>(null);
+  const hasAutoConnected = useRef(false);
+  const isConnecting = useRef(false);
 
   useEffect(() => {
     const loadDictionary = async () => {
@@ -90,7 +92,20 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
   const serialLib =
     !Navigator.serial && Navigator.usb ? serial : Navigator.serial;
 
+  useEffect(() => {
+    if (hasAutoConnected.current) return;
+    hasAutoConnected.current = true;
+
+    if (!Navigator.serial && !Navigator.usb) {
+      alert("Your web browser is not supported; please use Chrome");
+      return;
+    }
+    connectToDevice();
+  }, []);
+
   const connectToDevice = async () => {
+    if (isConnecting.current) return;
+    isConnecting.current = true;
     setLoading(true);
     try {
       const result = (await serialLib.requestPort()) as unknown as SerialPort;
@@ -124,6 +139,7 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
       toast.error(message);
     } finally {
       setLoading(false);
+      isConnecting.current = false;
     }
   };
 


### PR DESCRIPTION
## Summary
- auto-connect to device when browser supports Web Serial or USB
- alert users on unsupported browsers
- guard connection logic to avoid repeated connect attempts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a1423db994832daab5a33ff5051def