### PR TITLE
chore: simplify device tool layout

### DIFF
--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -4,7 +4,6 @@ import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { RadioGroup, RadioGroupItem } from "./ui/radio-group";
-import { Switch } from "./ui/switch";
 import {
   Select,
   SelectContent,
@@ -143,15 +142,6 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
     }
   };
 
-  const disconnectDevice = () => {
-    if (device) {
-      device.disconnect();
-      setDevice(null);
-      setEsploader(null);
-      handleAddInfo("Device disconnected");
-    }
-  };
-
   const createFlashOptions = (buffer: ArrayBuffer): FlashOptions => {
     const data = Buffer.from(buffer).toString("binary");
     return {
@@ -264,17 +254,7 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
           loading={loading}
           className="border w-full h-full rounded flex flex-row items-center justify-between relative backdrop-blur-sm "
         >
-          <div className="flex items-left flex-col gap-12 flex-1 p-5 ">
-            <div className="flex items-center gap-2">
-              <Switch id="device-connected" disabled checked={!!device} />
-              <Label htmlFor="device-connected">{dict.tools.title}</Label>
-              <Button
-                size="sm"
-                onClick={device ? disconnectDevice : connectToDevice}
-              >
-                {device ? dict.tools.disconnectBtn : dict.tools.connectBtn}
-              </Button>
-            </div>
+          <div className="flex items-left flex-col gap-8 flex-1 p-5 ">
             <div className="flex items-center gap-2">
               <Label>{dict.tools.flashMode} :</Label>
               <RadioGroup


### PR DESCRIPTION
## Summary
- remove connection controls from device tool
- move flash mode selection to the top of the layout

## Testing
- `pnpm lint` *(fails: 'ThemeProvider' is defined but never used...)*
- `pnpm lint --file components/deviceTool.tsx`
- `pnpm build` *(fails: ReferenceError: navigator is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a1461c0e40832d93d109ba8aac5422