### PR TITLE
Sort online firmware list by name

### DIFF
--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -46,6 +46,9 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
       const res = await fetch("/api/makcu");
       if (!res.ok) throw new Error("network");
       const data: DataListType[] = await res.json();
+      data.sort((a, b) =>
+        b.name.localeCompare(a.name, undefined, { numeric: true })
+      );
       setOnlineDataList(data);
     } catch (error) {
       console.error("Failed to fetch online data list", error);


### PR DESCRIPTION
## Summary
- sort downloaded firmware data by filename before setting state

## Testing
- `pnpm lint` *(fails: 'ThemeProvider' is defined but never used, 'page_routes' is defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a14a65be80832d9feac1526e761bcc