### PR TITLE
Group firmware options by USB port

### DIFF
--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -7,7 +7,9 @@ import { RadioGroup, RadioGroupItem } from "./ui/radio-group";
 import {
   Select,
   SelectContent,
+  SelectLabel,
   SelectItem,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
@@ -40,6 +42,8 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
   };
 
   const [onlineDataList, setOnlineDataList] = useState<DataListType[]>([]);
+  const [leftFiles, setLeftFiles] = useState<DataListType[]>([]);
+  const [rightFiles, setRightFiles] = useState<DataListType[]>([]);
 
   const fetchOnlineDataList = async () => {
     try {
@@ -49,6 +53,18 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
       data.sort((a, b) =>
         b.name.localeCompare(a.name, undefined, { numeric: true })
       );
+      const left = data
+        .filter((item) => /LEFT/i.test(item.name))
+        .sort((a, b) =>
+          b.name.localeCompare(a.name, undefined, { numeric: true })
+        );
+      const right = data
+        .filter((item) => /RIGHT/i.test(item.name))
+        .sort((a, b) =>
+          b.name.localeCompare(a.name, undefined, { numeric: true })
+        );
+      setLeftFiles(left);
+      setRightFiles(right);
       setOnlineDataList(data);
     } catch (error) {
       console.error("Failed to fetch online data list", error);
@@ -312,7 +328,15 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
                       <SelectValue placeholder={dict.tools.list} />
                     </SelectTrigger>
                     <SelectContent>
-                      {onlineDataList.map((item) => (
+                      <SelectLabel>{dict.tools.usb1Left}</SelectLabel>
+                      {leftFiles.map((item) => (
+                        <SelectItem key={item.name} value={item.name}>
+                          {item.name}
+                        </SelectItem>
+                      ))}
+                      <SelectSeparator />
+                      <SelectLabel>{dict.tools.usb3Right}</SelectLabel>
+                      {rightFiles.map((item) => (
                         <SelectItem key={item.name} value={item.name}>
                           {item.name}
                         </SelectItem>

--- a/dictionaries/cn.json
+++ b/dictionaries/cn.json
@@ -73,7 +73,9 @@
     "clearDebugInfo": "清除调试信息",
     "uploadFirmware": "上传固件",
     "connectSuccess": "连接成功",
-    "flashSuccess": "固件刷写成功"
+    "flashSuccess": "固件刷写成功",
+    "usb1Left": "USB1 左侧",
+    "usb3Right": "USB3 右侧"
   },
   "docs": {
     "on_this_page": "On this page",

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -77,7 +77,9 @@
     "clearDebugInfo": "Clear Debug Info",
     "uploadFirmware": "Upload Firmware",
     "connectSuccess": "Connect Success",
-    "flashSuccess": "Firmware Flash Success"
+    "flashSuccess": "Firmware Flash Success",
+    "usb1Left": "USB1 Left",
+    "usb3Right": "USB3 Right"
   },
   "docs": {
     "on_this_page": "On this page",


### PR DESCRIPTION
## Summary
- Split fetched firmware files into USB1 left and USB3 right groups
- Display firmware groups with section labels in select dropdown
- Add english and chinese translations for USB1 left and USB3 right labels

## Testing
- `pnpm lint --file components/deviceTool.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a14b8e3ba4832db42005abad4a0a52