### PR TITLE
Show twenty Discord members and remove extra card

### DIFF
--- a/components/discord.tsx
+++ b/components/discord.tsx
@@ -41,9 +41,6 @@ export const DiscordCard = () => {
               </Card>
             );
           })}
-        <Card className="p-3 relative flex gap-3 items-center bg-transparent backdrop-blur-sm justify-center uppercase max-w-40 min-w-40 overflow-hidden">
-          <span className="text-center">...(more)</span>
-        </Card>
       </div>
     </div>
   );

--- a/store/discordSlice.ts
+++ b/store/discordSlice.ts
@@ -43,7 +43,7 @@ export const fetchDiscordData = createAsyncThunk(
       }
       const data = await response.json();
       // 随机
-      data.members = data.members.sort(() => Math.random() - 0.5).slice(0, 19);
+      data.members = data.members.sort(() => Math.random() - 0.5).slice(0, 20);
       return data;
     } catch (error: any) {
       return rejectWithValue(error.message);


### PR DESCRIPTION
## Summary
- increase random members slice to 20
- remove placeholder Discord card

## Testing
- `pnpm lint` *(fails: 'ThemeProvider' is defined but never used, etc.)*
- `pnpm build` *(fails: ReferenceError: navigator is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a14f175b84832d9a5ab368fb0b06e0