### PR TITLE
feat: display list descriptions

### DIFF
--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -92,7 +92,11 @@ export default function Home() {
                 Icon={IconComponent}
                 title={item.title}
                 number={number}
-                description={item.description}
+                description={
+                  Array.isArray(item.description)
+                    ? item.description
+                    : [item.description]
+                }
               />
             );
           })}

--- a/components/info-card.tsx
+++ b/components/info-card.tsx
@@ -7,7 +7,7 @@ export type InfoCardProps = {
   >;
   title: string;
   number: string;
-  description: string;
+  description: string[];
 };
 export const InfoCard: React.FC<InfoCardProps> = (props) => {
   return (
@@ -18,7 +18,11 @@ export const InfoCard: React.FC<InfoCardProps> = (props) => {
       </div>
       <div className=" flex flex-col p-3 text-left gap-2">
         <span className="text-xl">{props.number}</span>
-        <p className="pt-2 text-sm">{props.description}</p>
+        <ul className="pt-2 text-sm space-y-1">
+          {props.description.map((line, index) => (
+            <li key={index}>{line}</li>
+          ))}
+        </ul>
       </div>
     </Card>
   );

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -30,7 +30,11 @@
         "icon": "cpu",
         "title": "Full Pass-Through",
         "number": "100%",
-        "description": "Full mouse, keyboard and controller pass-through."
+        "description": [
+          "Mouse",
+          "Keyboard (soon)",
+          "Controller (xim needed)"
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary
- render multi-line descriptions in InfoCard
- support array descriptions in home info section

## Testing
- `pnpm lint` *(fails: ThemeProvider is defined but never used etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a15af29c9c832d8c1f55027863a3ac