### PR TITLE
Show Discord server member count

### DIFF
--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -15,8 +15,8 @@ import { RootState } from "@/store";
 
 export default function Home() {
   const dict = useDictionary();
-  const presenceCount = useSelector(
-    (state: RootState) => state.discord.data?.presence_count
+  const memberCount = useSelector(
+    (state: RootState) => state.discord.data?.member_count
   );
 
   const iconMap = {
@@ -84,7 +84,7 @@ export default function Home() {
             const IconComponent = iconMap[item.icon as keyof typeof iconMap];
             const number =
               item.icon === "users_round"
-                ? presenceCount?.toString() ?? ""
+                ? memberCount?.toString() ?? ""
                 : item.number;
             return (
               <InfoCard

--- a/dictionaries/cn.json
+++ b/dictionaries/cn.json
@@ -15,8 +15,8 @@
     "list": [
       {
         "icon": "users_round",
-        "title": "活跃用户",
-        "number": "2000+",
+        "title": "服务器成员",
+        "number": "",
         "description": "我们拥有大量活跃用户，以及由优秀用户社区打造的强大技术团队。"
       },
       {

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -14,12 +14,12 @@
   "info": {
     "title": "Why are we better?",
     "list": [
-      {
-        "icon": "users_round",
-        "title": "Active Users",
-        "number": "",
-        "description": "We have a large number of active users and a strong technical team built by an excellent user community."
-      },
+        {
+          "icon": "users_round",
+          "title": "Server members",
+          "number": "",
+          "description": "We have a large number of active users and a strong technical team built by an excellent user community."
+        },
       {
         "icon": "mouse",
         "title": "Supported Mice",

--- a/store/discordSlice.ts
+++ b/store/discordSlice.ts
@@ -6,6 +6,7 @@ interface DiscordType {
   channels: any[];
   members: Member[];
   presence_count: number;
+  member_count?: number;
 }
 
 export interface Member {
@@ -44,6 +45,18 @@ export const fetchDiscordData = createAsyncThunk(
       const data = await response.json();
       // 随机
       data.members = data.members.sort(() => Math.random() - 0.5).slice(0, 20);
+
+      const inviteCode = data.instant_invite?.split("/").pop();
+      if (inviteCode) {
+        const inviteRes = await fetch(
+          `https://discord.com/api/invites/${inviteCode}?with_counts=true`
+        );
+        if (inviteRes.ok) {
+          const inviteData = await inviteRes.json();
+          data.member_count =
+            inviteData.approximate_member_count ?? inviteData.member_count;
+        }
+      }
       return data;
     } catch (error: any) {
       return rejectWithValue(error.message);


### PR DESCRIPTION
## Summary
- label server information card as "Server members" and remove hard-coded counts
- pull member totals from Discord invite API and expose as `member_count`
- display fetched server membership in first info card

## Testing
- `pnpm lint` *(fails: '@typescript-eslint/no-unused-vars' and related errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a15b138954832db2970fe14759dff9