### PR TITLE
Remove link from footer copyright

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -10,11 +10,7 @@ export function Footer({ dict }: { dict: Dictionary }) {
         <div className="flex items-center gap-3">
         
           <p className="text-center">
-            Copyright &copy; 2024 - 2025
-            <Link className="px-1 underline underline-offset-2" href="https://github.com/makcuTeam">
-              MakcuTeam
-            </Link>
-            .
+            Copyright &copy; 2024 - 2025 Makcu.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- display project name as plain text in footer instead of link

## Testing
- `pnpm lint` *(fails: 'ThemeProvider' is defined but never used, Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a15b124bb0832d900367ac50fc50de