### PR TITLE
feat(deviceTool): configurable firmware filters and empty state

### DIFF
--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -30,6 +30,21 @@ interface DataListType {
   downloadUrl: string;
 }
 
+const FIRMWARE_PATTERNS: Record<"left" | "right", RegExp> = {
+  left: /LEFT/i,
+  right: /RIGHT/i,
+};
+
+const filterFirmware = (
+  files: DataListType[],
+  side: keyof typeof FIRMWARE_PATTERNS,
+) =>
+  files
+    .filter((item) => FIRMWARE_PATTERNS[side].test(item.name))
+    .sort((a, b) =>
+      b.name.localeCompare(a.name, undefined, { numeric: true }),
+    );
+
 export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
   const [dict, setDict] = useState<Dictionary>();
   const debugRef = useRef<DebugWindowRef | null>(null);
@@ -53,16 +68,8 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
       data.sort((a, b) =>
         b.name.localeCompare(a.name, undefined, { numeric: true })
       );
-      const left = data
-        .filter((item) => /LEFT/i.test(item.name))
-        .sort((a, b) =>
-          b.name.localeCompare(a.name, undefined, { numeric: true })
-        );
-      const right = data
-        .filter((item) => /RIGHT/i.test(item.name))
-        .sort((a, b) =>
-          b.name.localeCompare(a.name, undefined, { numeric: true })
-        );
+      const left = filterFirmware(data, "left");
+      const right = filterFirmware(data, "right");
       setLeftFiles(left);
       setRightFiles(right);
       setOnlineDataList(data);
@@ -329,18 +336,30 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
                     </SelectTrigger>
                     <SelectContent>
                       <SelectLabel>{dict.tools.usb1Left}</SelectLabel>
-                      {leftFiles.map((item) => (
-                        <SelectItem key={item.name} value={item.name}>
-                          {item.name}
+                      {leftFiles.length === 0 ? (
+                        <SelectItem value="no-left" disabled>
+                          {dict.tools.noLeftFirmware}
                         </SelectItem>
-                      ))}
+                      ) : (
+                        leftFiles.map((item) => (
+                          <SelectItem key={item.name} value={item.name}>
+                            {item.name}
+                          </SelectItem>
+                        ))
+                      )}
                       <SelectSeparator />
                       <SelectLabel>{dict.tools.usb3Right}</SelectLabel>
-                      {rightFiles.map((item) => (
-                        <SelectItem key={item.name} value={item.name}>
-                          {item.name}
+                      {rightFiles.length === 0 ? (
+                        <SelectItem value="no-right" disabled>
+                          {dict.tools.noRightFirmware}
                         </SelectItem>
-                      ))}
+                      ) : (
+                        rightFiles.map((item) => (
+                          <SelectItem key={item.name} value={item.name}>
+                            {item.name}
+                          </SelectItem>
+                        ))
+                      )}
                     </SelectContent>
                   </Select>
                 </div>

--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -64,15 +64,15 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
     try {
       const res = await fetch("/api/makcu");
       if (!res.ok) throw new Error("network");
-      const data: DataListType[] = await res.json();
-      data.sort((a, b) =>
+      const dataList: DataListType[] = await res.json();
+      dataList.sort((a, b) =>
         b.name.localeCompare(a.name, undefined, { numeric: true })
       );
-      const left = filterFirmware(data, "left");
-      const right = filterFirmware(data, "right");
+      const left = filterFirmware(dataList, "left");
+      const right = filterFirmware(dataList, "right");
       setLeftFiles(left);
       setRightFiles(right);
-      setOnlineDataList(data);
+      setOnlineDataList(dataList);
     } catch (error) {
       console.error("Failed to fetch online data list", error);
       handleAddInfo(

--- a/dictionaries/cn.json
+++ b/dictionaries/cn.json
@@ -72,7 +72,9 @@
     "connectSuccess": "连接成功",
     "flashSuccess": "固件刷写成功",
     "usb1Left": "USB1 左侧",
-    "usb3Right": "USB3 右侧"
+    "usb3Right": "USB3 右侧",
+    "noLeftFirmware": "未找到左侧固件",
+    "noRightFirmware": "未找到右侧固件"
   },
   "docs": {
     "on_this_page": "On this page",

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -80,7 +80,9 @@
     "connectSuccess": "Connect Success",
     "flashSuccess": "Firmware Flash Success",
     "usb1Left": "USB1 Left",
-    "usb3Right": "USB3 Right"
+    "usb3Right": "USB3 Right",
+    "noLeftFirmware": "No left firmware found",
+    "noRightFirmware": "No right firmware found"
   },
   "docs": {
     "on_this_page": "On this page",


### PR DESCRIPTION
## Summary
- add configurable firmware regex helpers
- show messages when no left/right firmware is available

## Testing
- `pnpm lint` *(fails: '@typescript-eslint/no-unused-vars', '@typescript-eslint/no-explicit-any', 'react/display-name', 'react-hooks/exhaustive-deps')*

------
https://chatgpt.com/codex/tasks/task_e_68a15eb2699c832d9e0f90e8c6f9b199