### PR TITLE
feat: show message when firmware list empty

### DIFF
--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -350,18 +350,30 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
                     </SelectTrigger>
                     <SelectContent>
                       <SelectLabel>{dict.tools.usb1Left}</SelectLabel>
-                      {leftFiles.map((item) => (
-                        <SelectItem key={item.name} value={item.name}>
-                          {item.name}
+                      {leftFiles.length > 0 ? (
+                        leftFiles.map((item) => (
+                          <SelectItem key={item.name} value={item.name}>
+                            {item.name}
+                          </SelectItem>
+                        ))
+                      ) : (
+                        <SelectItem disabled value="no-left">
+                          {dict.tools.noLeftFirmware}
                         </SelectItem>
-                      ))}
+                      )}
                       <SelectSeparator />
                       <SelectLabel>{dict.tools.usb3Right}</SelectLabel>
-                      {rightFiles.map((item) => (
-                        <SelectItem key={item.name} value={item.name}>
-                          {item.name}
+                      {rightFiles.length > 0 ? (
+                        rightFiles.map((item) => (
+                          <SelectItem key={item.name} value={item.name}>
+                            {item.name}
+                          </SelectItem>
+                        ))
+                      ) : (
+                        <SelectItem disabled value="no-right">
+                          {dict.tools.noRightFirmware}
                         </SelectItem>
-                      ))}
+                      )}
                     </SelectContent>
                   </Select>
                 </div>

--- a/dictionaries/cn.json
+++ b/dictionaries/cn.json
@@ -72,7 +72,9 @@
     "connectSuccess": "连接成功",
     "flashSuccess": "固件刷写成功",
     "usb1Left": "USB1 左侧",
-    "usb3Right": "USB3 右侧"
+    "usb3Right": "USB3 右侧",
+    "noLeftFirmware": "未找到左侧固件",
+    "noRightFirmware": "未找到右侧固件"
   },
   "docs": {
     "on_this_page": "On this page",

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -80,7 +80,9 @@
     "connectSuccess": "Connect Success",
     "flashSuccess": "Firmware Flash Success",
     "usb1Left": "USB1 Left",
-    "usb3Right": "USB3 Right"
+    "usb3Right": "USB3 Right",
+    "noLeftFirmware": "No left firmware found",
+    "noRightFirmware": "No right firmware found"
   },
   "docs": {
     "on_this_page": "On this page",


### PR DESCRIPTION
## Summary
- show placeholder entries when no left/right firmware is available
- add i18n strings for empty firmware lists

## Testing
- `pnpm lint --file components/deviceTool.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a16381bda0832d86b0c44ce53b1a5e