### PR TITLE
Log firmware URLs in device tool

### DIFF
--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -82,6 +82,9 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
             console.log(msg);
             return false;
           }
+          const msg = `Download URL for ${item.name}: ${item.downloadUrl}`;
+          handleAddInfo(msg);
+          console.log(msg);
           return true;
         });
         dataList.sort((a, b) =>
@@ -267,6 +270,15 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
     }
 
     try {
+      const urlMsg = `Selected firmware URL: ${selected.downloadUrl}`;
+      handleAddInfo(urlMsg);
+      console.log(urlMsg);
+      if (!/^https:\/\/raw\.githubusercontent\.com\//.test(selected.downloadUrl)) {
+        const warnMsg =
+          "Warning: selected firmware URL may not be a raw.githubusercontent.com resource";
+        handleAddInfo(warnMsg);
+        console.warn(warnMsg);
+      }
       handleAddInfo(`Downloading ${selected.name}...`);
       const response = await fetch(selected.downloadUrl);
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- log each firmware entry's downloadUrl when fetching
- show selected firmware URL before flashing and warn if not from raw.githubusercontent.com

## Testing
- `pnpm lint` (fails: TypeScript/ESLint errors in unrelated files)
- `pnpm build` (fails: ReferenceError: navigator is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68a16d528f68832db263d50a35056c07