### PR TITLE
Handle unsupported browsers in device tool

### DIFF
--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -143,6 +143,8 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
 
   const [progress, setProgress] = useState(0);
   const [onlineSelect, setOnlineSelect] = useState<string>();
+  const [browserSupported, setBrowserSupported] = useState(true);
+  const [showBrowserWarning, setShowBrowserWarning] = useState(true);
 
   const fileRef = useRef<HTMLInputElement>(null);
   const hasAutoConnected = useRef(false);
@@ -161,13 +163,12 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
     !Navigator.serial && Navigator.usb ? serial : Navigator.serial;
 
   useEffect(() => {
-    if (hasAutoConnected.current) return;
-    hasAutoConnected.current = true;
+    setBrowserSupported(!!(Navigator.serial || Navigator.usb));
+  }, []);
 
-    if (!Navigator.serial && !Navigator.usb) {
-      alert("Your web browser is not supported; please use Chrome");
-      return;
-    }
+  useEffect(() => {
+    if (hasAutoConnected.current || !browserSupported) return;
+    hasAutoConnected.current = true;
 
     const handleConnect = (event: Event) => {
       const port =
@@ -193,7 +194,7 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
     return () => {
       Navigator.serial?.removeEventListener("connect", handleConnect);
     };
-  }, []);
+  }, [browserSupported]);
 
   const connectToDevice = async (port?: SerialPort) => {
     if (isConnecting.current) return;
@@ -344,8 +345,33 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
     setConfig({ mode });
   };
 
+  useEffect(() => {
+    if (dict && !browserSupported) {
+      toast.warning(dict.tools.browserNotSupported);
+    }
+  }, [dict, browserSupported]);
+
   if (!dict) {
     return <Loading loading={true} className="w-full h-64" />;
+  }
+
+  if (!browserSupported) {
+    return (
+      <div>
+        {showBrowserWarning && (
+          <div className="mb-4 flex items-center justify-between rounded border border-yellow-200 bg-yellow-100 p-4 text-yellow-800">
+            <span>{dict.tools.browserNotSupported}</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowBrowserWarning(false)}
+            >
+              ×
+            </Button>
+          </div>
+        )}
+      </div>
+    );
   }
 
   return (

--- a/dictionaries/cn.json
+++ b/dictionaries/cn.json
@@ -74,7 +74,8 @@
     "usb1Left": "USB1 左侧",
     "usb3Right": "USB3 右侧",
     "noLeftFirmware": "未找到左侧固件",
-    "noRightFirmware": "未找到右侧固件"
+    "noRightFirmware": "未找到右侧固件",
+    "browserNotSupported": "您的浏览器不支持 Web Serial/WebUSB。请使用 Chrome、Edge 或其他基于 Chromium 的浏览器。"
   },
   "docs": {
     "on_this_page": "On this page",

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -82,7 +82,8 @@
     "usb1Left": "USB1 Left",
     "usb3Right": "USB3 Right",
     "noLeftFirmware": "No left firmware found",
-    "noRightFirmware": "No right firmware found"
+    "noRightFirmware": "No right firmware found",
+    "browserNotSupported": "Your browser does not support Web Serial/WebUSB. Please use Chrome, Edge, or another Chromium-based browser."
   },
   "docs": {
     "on_this_page": "On this page",


### PR DESCRIPTION
## Summary
- check for Web Serial/WebUSB support on mount and guard device connection
- show dismissible warning when the browser is unsupported
- document supported browsers in translations

## Testing
- `pnpm lint` *(fails: 'ThemeProvider' is defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a173cac498832d8531b68dbce036a3