### PR TITLE
feat: update flashing baudrate

### DIFF
--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -209,7 +209,7 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
       const transport = new Transport(result, false, false);
       const flashOptions = {
         transport,
-        baudrate: 115200,
+        baudrate: 921600,
         terminal: {
           clean() {
             handleClearInfo();


### PR DESCRIPTION
## Summary
- adjust esptool flash options to use 921600 baud rate

## Testing
- `pnpm lint` *(fails: various eslint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a1806866b4832da59f81a452a6fe76