### PR TITLE
Auto-trigger firmware flashing and remove manual button

### DIFF
--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -292,8 +292,14 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
     }
   };
 
-  const flashOnline = async () => {
-    const selected = onlineDataList.find((item) => item.name === onlineSelect);
+  const flashOnline = async (firmwareName: string) => {
+    if (!device) {
+      const msg = "No device connected";
+      handleAddInfo(msg);
+      toast.error(msg);
+      return;
+    }
+    const selected = onlineDataList.find((item) => item.name === firmwareName);
     if (!selected) {
       handleAddInfo("Selected firmware not found");
       return;
@@ -332,16 +338,15 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
     if (files && files.length > 0) {
       const [firstFile] = files;
       setSelectedFile(firstFile);
+      if (!device) {
+        const msg = "No device connected";
+        handleAddInfo(msg);
+        toast.error(msg);
+        return;
+      }
+      flashDevice(firstFile);
     } else {
       setSelectedFile(null);
-    }
-  };
-
-  const handleFlashClick = () => {
-    if (config.mode === "offline" && selectedFile) {
-      flashDevice(selectedFile);
-    } else if (config.mode === "online") {
-      flashOnline();
     }
   };
 
@@ -436,7 +441,13 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
               ) : (
                 <div className="flex items-center gap-3">
                   <Label>{dict.tools.onlineFlash}</Label>
-                  <Select value={onlineSelect} onValueChange={setOnlineSelect}>
+                  <Select
+                    value={onlineSelect}
+                    onValueChange={(value) => {
+                      setOnlineSelect(value);
+                      flashOnline(value);
+                    }}
+                  >
                     <SelectTrigger className="w-[180px]">
                       <SelectValue placeholder={dict.tools.list} />
                     </SelectTrigger>
@@ -474,15 +485,6 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
                   </Select>
                 </div>
               )}
-              <Button
-                size="sm"
-                onClick={handleFlashClick}
-                disabled={
-                  !device || (config.mode === "offline" && !selectedFile)
-                }
-              >
-                {dict.tools.flash}
-              </Button>
             </div>
           </div>
         </Loading>

--- a/dictionaries/cn.json
+++ b/dictionaries/cn.json
@@ -62,7 +62,6 @@
     "flashMode": "刷写模式",
     "online": "在线",
     "offline": "离线",
-    "flash": "刷写",
     "firmware": "固件",
     "list": "设备列表",
     "onlineFlash": "在线刷写",

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -70,7 +70,6 @@
     "flashMode": "Flash Mode",
     "online": "Online",
     "offline": "Offline",
-    "flash": "Flash",
     "firmware": "Firmware",
     "list": "Select Firmware",
     "onlineFlash": "Online Flash",


### PR DESCRIPTION
## Summary
- Trigger offline flashing automatically when a firmware file is chosen, with a device connection check.
- Start online flashing immediately on dropdown selection and validate device presence.
- Remove deprecated Flash button text from English and Chinese dictionaries.

## Testing
- `pnpm lint` *(fails: errors in existing files unrelated to changes)*

------
https://chatgpt.com/codex/tasks/task_e_68a180f59a14832db44d6897a9bb17c3