### PR TITLE
chore: filter unwanted flash warning

### DIFF
--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -54,6 +54,11 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
   const [dict, setDict] = useState<Dictionary>();
   const debugRef = useRef<DebugWindowRef | null>(null);
   const handleAddInfo = (info: string) => {
+    const imageWarning =
+      "Image file at 0x0 doesn't look like an image file, so not changing any flash settings.";
+    if (info.includes(imageWarning)) {
+      return;
+    }
     debugRef.current?.addInfo(info);
   };
 


### PR DESCRIPTION
## Summary
- ignore esptool's image file warning in DeviceTool

## Testing
- `pnpm lint` *(fails: ThemeProvider is defined but never used, Unexpected any...)*
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68a1839f90a8832da03fdb95adad7e9f