### PR TITLE
feat: detect flash parameters

### DIFF
--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -233,6 +233,14 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
 
   const createFlashOptions = (buffer: ArrayBuffer): FlashOptions => {
     const data = Buffer.from(buffer).toString("binary");
+    const chip = esploader?.chip as {
+      flashMode?: string;
+      flashFreq?: string;
+      flashSize?: string;
+    } | undefined;
+    const flashMode = chip?.flashMode ?? "dio";
+    const flashFreq = chip?.flashFreq ?? "40m";
+    const flashSize = chip?.flashSize ?? "keep";
     return {
       fileArray: [
         {
@@ -240,11 +248,11 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
           address: 0x0,
         },
       ],
-      flashSize: "keep",
+      flashSize,
       eraseAll: false,
       compress: true,
-      flashMode: "dio",
-      flashFreq: "40m",
+      flashMode,
+      flashFreq,
       reportProgress(fileIndex, written, total) {
         setProgress((written / total) * 100);
       },


### PR DESCRIPTION
## Summary
- detect flash mode, frequency, and size from connected ESP device
- use detected values when preparing flash options

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: React hook dependency warnings and unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_68a18f2b2634832d8db06a3bbf02fa8f