### PR TITLE
Disable compression in device flasher

### DIFF
--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -250,7 +250,7 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
       ],
       flashSize,
       eraseAll: false,
-      compress: true,
+      compress: false,
       flashMode,
       flashFreq,
       reportProgress(fileIndex, written, total) {


### PR DESCRIPTION
## Summary
- disable binary compression when creating ESP flashing options

## Testing
- `pnpm lint` *(fails: unused variables and type warnings in unrelated files)*
- `pnpm build` *(fails: ReferenceError `navigator is not defined` during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_68a193cc8c24832d966b526149c3f642