### PR TITLE
Restrict serial connections to approved devices

### DIFF
--- a/lib/serialDevices.ts
+++ b/lib/serialDevices.ts
@@ -1,0 +1,19 @@
+export interface AllowedDevice {
+  vendorId: number;
+  productId: number;
+}
+
+// Ordered list of approved USB vendor/product ID pairs.
+// Extend this list to support additional devices in the future.
+export const ALLOWED_DEVICES: AllowedDevice[] = [
+  { vendorId: 0x0403, productId: 0x6001 },
+  { vendorId: 0x1a86, productId: 0x55d3 },
+  { vendorId: 0x303a, productId: 0x0009 },
+  { vendorId: 0x303a, productId: 0x1001 },
+];
+
+export const isAllowedDevice = (info: SerialPortInfo): boolean =>
+  ALLOWED_DEVICES.some(
+    (d) =>
+      info.usbVendorId === d.vendorId && info.usbProductId === d.productId,
+  );


### PR DESCRIPTION
## Summary
- centralize approved USB VID/PID pairs and helper to verify them
- prioritize auto-connection by allowed device order
- ignore unsupported serial ports and prompt manual selection

## Testing
- `pnpm lint` *(fails: 'ThemeProvider' defined but never used, etc.)*
- `pnpm lint --file lib/serialDevices.ts --file components/deviceTool.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a1981e8580832d94e472cf73dd31b7