### PR TITLE
Enable flash compression in device tool

### DIFF
--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -277,7 +277,7 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
       ],
       flashSize,
       eraseAll: false,
-      compress: false,
+      compress: true,
       flashMode,
       flashFreq,
       reportProgress(fileIndex, written, total) {


### PR DESCRIPTION
## Summary
- ensure createFlashOptions enables compression when flashing devices

## Testing
- `pnpm lint` *(fails: unused vars and other lint errors)*
- `pnpm build` *(fails: ReferenceError: navigator is not defined during prerendering)*

------
https://chatgpt.com/codex/tasks/task_e_68a19c39a138832dab50a93bfd3af253