### PR TITLE
feat: add device not found instructions

### DIFF
--- a/components/DebugWindow.tsx
+++ b/components/DebugWindow.tsx
@@ -52,7 +52,7 @@ export const DebugWindow = forwardRef<
         {info.map((e, k) => (
           <span
             key={k}
-            className="block border-b text-xs border-gray-300 py-2 px-4 dark:border-white/5"
+            className="block whitespace-pre-line border-b text-xs border-gray-300 py-2 px-4 dark:border-white/5"
           >
             {e}
           </span>

--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -165,7 +165,9 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
     const ports = await serialLib.getPorts();
     const allowed = ports.filter((p) => isAllowedDevice(p.getInfo()));
     if (allowed.length === 0) {
-      handleAddInfo("No allowed devices found; waiting for manual connection");
+      handleAddInfo(
+        "MAKCU Not found:\nHold button,\nconnect usb cable,\nlet go of button",
+      );
       return;
     }
     allowed.sort(


### PR DESCRIPTION
## Summary
- show instructions when no allowed devices are found
- allow debug messages to render multiline text

## Testing
- `pnpm lint` *(fails: Unexpected any and unused variable errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a1add88fdc832d85a2558a973d8428