### PR TITLE
Align device tool and debug window heights

### DIFF
--- a/components/DebugWindow.tsx
+++ b/components/DebugWindow.tsx
@@ -38,7 +38,7 @@ export const DebugWindow = forwardRef<
   });
 
   return (
-    <div className="flex-1 border rounded backdrop-blur-sm">
+    <div className="flex-1 h-64 border rounded backdrop-blur-sm">
       <div className="p-4  border-b border-b-gray-300 dark:border-white/5">
         <Button size="xs" onClick={() => setInfo([])}>
           {props.dict.tools.clearDebugInfo}

--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -383,7 +383,7 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
       <div className="flex flex-row gap-5">
         <Loading
           loading={loading}
-          className="border w-full h-full rounded flex flex-row items-center justify-between relative backdrop-blur-sm "
+          className="border w-full h-64 rounded flex flex-row items-center justify-between relative backdrop-blur-sm "
         >
           <div className="flex items-left flex-col gap-8 flex-1 p-5 ">
             <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- Apply fixed height to device tool's main loading wrapper
- Give debug window a matching fixed height

## Testing
- `pnpm lint` *(fails: 'ThemeProvider' is defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cacfbf80832d8e937bdce224c50f