### PR TITLE
Fix debug window clear button size

### DIFF
--- a/components/DebugWindow.tsx
+++ b/components/DebugWindow.tsx
@@ -40,7 +40,7 @@ export const DebugWindow = forwardRef<
   return (
     <div className="flex-1 h-64 border rounded backdrop-blur-sm">
       <div className="p-4  border-b border-b-gray-300 dark:border-white/5">
-        <Button size="xs" onClick={() => setInfo([])}>
+        <Button onClick={() => setInfo([])}>
           {props.dict.tools.clearDebugInfo}
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- use default size for clear debug info button to match connect button dimensions

## Testing
- `pnpm lint` *(fails: ThemeProvider is defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cd1d63f4832d96ad2e15dcc39669