### PR TITLE
fix: standardize debug window and control font sizes

### DIFF
--- a/components/DebugWindow.tsx
+++ b/components/DebugWindow.tsx
@@ -52,7 +52,7 @@ export const DebugWindow = forwardRef<
         {info.map((e, k) => (
           <span
             key={k}
-            className="block whitespace-pre-line border-b text-xs border-gray-300 py-2 px-4 dark:border-white/5"
+            className="block whitespace-pre-line border-b text-sm border-gray-300 py-2 px-4 dark:border-white/5"
           >
             {e}
           </span>

--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -390,7 +390,7 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
               <Button onClick={connectToDevice}>{dict.tools.connectBtn}</Button>
             </div>
             <div className="flex items-center gap-2">
-              <Label>{dict.tools.flashMode} :</Label>
+              <Label className="text-sm">{dict.tools.flashMode} :</Label>
               <RadioGroup
                 value={config.mode}
                 onValueChange={handleModeChange}
@@ -398,13 +398,13 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
               >
                 <div className="flex items-center space-x-2">
                   <RadioGroupItem value="online" id="online" />
-                  <Label className="cursor-pointer" htmlFor="online">
+                  <Label className="cursor-pointer text-sm" htmlFor="online">
                     {dict.tools.online}
                   </Label>
                 </div>
                 <div className="flex items-center space-x-2">
                   <RadioGroupItem value="offline" id="offline" />
-                  <Label className="cursor-pointer" htmlFor="offline">
+                  <Label className="cursor-pointer text-sm" htmlFor="offline">
                     {dict.tools.offline}
                   </Label>
                 </div>
@@ -413,7 +413,7 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
             <div className="flex items-center gap-3">
               {config.mode === "offline" ? (
                 <div className="flex items-center gap-3">
-                  <Label>{dict.tools.offlineFlash}</Label>
+                  <Label className="text-sm">{dict.tools.offlineFlash}</Label>
                   <Button
                     variant={"outline"}
                     onClick={() => fileRef.current?.click()}
@@ -437,7 +437,7 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
                 </div>
               ) : (
                 <div className="flex items-center gap-3">
-                  <Label>{dict.tools.onlineFlash}</Label>
+                  <Label className="text-sm">{dict.tools.onlineFlash}</Label>
                   <Select
                     value={onlineSelect}
                     onValueChange={(value) => {
@@ -445,7 +445,7 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
                       flashOnline(value);
                     }}
                   >
-                    <SelectTrigger className="w-[180px]">
+                    <SelectTrigger className="w-[180px] text-sm">
                       <SelectValue placeholder={dict.tools.list} />
                     </SelectTrigger>
                     <SelectContent>


### PR DESCRIPTION
## Summary
- align debug window log entries with other controls by using `text-sm`
- enforce consistent `text-sm` styling on labels and select triggers

## Testing
- `pnpm lint` *(fails: unused variables and other issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ced93304832da7a8b5d86e9690ba