### PR TITLE
Make device panel flex share row with debug window

### DIFF
--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -383,7 +383,7 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
       <div className="flex flex-row gap-5">
         <Loading
           loading={loading}
-          className="border w-full h-64 rounded flex flex-row items-center justify-between relative backdrop-blur-sm "
+          className="border flex-1 h-64 rounded flex flex-row items-center justify-between relative backdrop-blur-sm "
         >
           <div className="flex items-left flex-col gap-8 flex-1 p-5 ">
             <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- adjust device tool loading container to flex-1 so it shares row with debug window

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: component and typescript lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d7777c6c832d8cece8ffcab96ef8