### PR TITLE
feat: add CH343 driver download notice

### DIFF
--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -487,6 +487,18 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
         </Loading>
         <DebugWindow ref={debugRef} dict={dict} progress={progress} />
       </div>
+      <p className="mt-4 text-sm text-center">
+        {dict.tools.driverNotice}
+        <a
+          href="https://github.com/terrafirma2021/MAKCM_v2_files/blob/main/CH343SER.EXE"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline text-blue-500"
+        >
+          {dict.tools.driverLink}
+        </a>
+        {dict.tools.driverNoticeEnd}
+      </p>
     </div>
   );
 };

--- a/dictionaries/cn.json
+++ b/dictionaries/cn.json
@@ -74,7 +74,10 @@
     "usb3Right": "USB3 右侧",
     "noLeftFirmware": "未找到左侧固件",
     "noRightFirmware": "未找到右侧固件",
-    "browserNotSupported": "您的浏览器不支持 Web Serial/WebUSB。请使用 Chrome、Edge 或其他基于 Chromium 的浏览器。"
+    "browserNotSupported": "您的浏览器不支持 Web Serial/WebUSB。请使用 Chrome、Edge 或其他基于 Chromium 的浏览器。",
+    "driverNotice": "如果你还没有安装CH343驱动程序，请点击",
+    "driverLink": "此链接",
+    "driverNoticeEnd": "下载"
   },
   "docs": {
     "on_this_page": "On this page",

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -82,7 +82,10 @@
     "usb3Right": "USB3 Right",
     "noLeftFirmware": "No left firmware found",
     "noRightFirmware": "No right firmware found",
-    "browserNotSupported": "Your browser does not support Web Serial/WebUSB. Please use Chrome, Edge, or another Chromium-based browser."
+    "browserNotSupported": "Your browser does not support Web Serial/WebUSB. Please use Chrome, Edge, or another Chromium-based browser.",
+    "driverNotice": "If you have not installed the CH343 driver yet then please click ",
+    "driverLink": "this link",
+    "driverNoticeEnd": " to download"
   },
   "docs": {
     "on_this_page": "On this page",


### PR DESCRIPTION
## Summary
- add CH343 driver download reminder to flash tool page
- localize reminder text in English and Chinese dictionaries

## Testing
- `pnpm lint` *(fails: ThemeProvider is defined but never used, and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a315577de4832db43b84e231ed9e37