### PR TITLE
fix: align driver notice and prevent debug overlay

### DIFF
--- a/components/DebugWindow.tsx
+++ b/components/DebugWindow.tsx
@@ -38,7 +38,7 @@ export const DebugWindow = forwardRef<
   });
 
   return (
-    <div className="flex-1 h-64 border rounded backdrop-blur-sm">
+    <div className="relative flex-1 h-64 border rounded backdrop-blur-sm">
       <div className="p-4  border-b border-b-gray-300 dark:border-white/5">
         <Button onClick={() => setInfo([])}>
           {props.dict.tools.clearDebugInfo}

--- a/components/deviceTool.tsx
+++ b/components/deviceTool.tsx
@@ -487,7 +487,7 @@ export const DeviceTool: React.FC<{ lang: Locale }> = ({ lang }) => {
         </Loading>
         <DebugWindow ref={debugRef} dict={dict} progress={progress} />
       </div>
-      <p className="mt-4 text-sm text-center">
+      <p className="relative z-10 mt-4 text-sm text-left">
         {dict.tools.driverNotice}
         <a
           href="https://github.com/terrafirma2021/MAKCM_v2_files/blob/main/CH343SER.EXE"


### PR DESCRIPTION
## Summary
- left-align CH343 driver notice and raise z-index so link is clickable
- position DebugWindow relatively to prevent overlapping nearby content

## Testing
- `pnpm lint` *(fails: 'ThemeProvider' is defined but never used, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a318f50454832d842c878e200c0068